### PR TITLE
[fix] Change ReadCommand to print value only if ssd has succeeded

### DIFF
--- a/src/shell/shell_command.py
+++ b/src/shell/shell_command.py
@@ -39,6 +39,8 @@ class ReadCommand(ICommand):
 
         with open(path.DATA_FILE_RESULT, "r") as result_file:
             ret = result_file.readline()
+
+        if not self._ssd_sp.returncode:
             LOGGER.debug(ret)
 
         return ReturnObject(self._ssd_sp.returncode, ret)


### PR DESCRIPTION
## 패치 타입
***
- [ ] feature 추가
- [ ] test 추가
- [ ] refactoring
- [ ] 버그 수정
- [x] 단순한 수정

## 설명
***
<!-- PR의 목적과 변경 사항에 대한 간략한 설명을 작성하세요 -->
- ReadCommand에서 ssd 프로세스가 비정상 종료 시 읽은 값을 출력하지 않도록 수정

## 테스트
***
<!-- 변경 사항을 테스트한 방법을 설명하세요 -->
- [ ] 로컬에서 Test 수행 했나요?

## 참고 사항
***
<!-- 기타 참고할 만한 사항을 작성하세요 (예: 스크린샷, 링크 등) -->
- 기타 참고 사항 1
- 기타 참고 사항 2
